### PR TITLE
Ignore `device_timestamp` for stories.

### DIFF
--- a/instaloader.py
+++ b/instaloader.py
@@ -921,12 +921,7 @@ class Instaloader:
                 count += 1
 
                 shortcode = item["code"] if "code" in item else "no_code"
-
-                date_float = item["device_timestamp"] if "device_timestamp" in item else item["taken_at"]
-                if date_float > 10000000000:
-                    # device_timestamp seems to sometimes be in milliseconds
-                    date_float /= 1000
-                date = datetime.fromtimestamp(date_float)
+                date = datetime.fromtimestamp(item["taken_at"])
 
                 dirname = self.dirname_pattern.format(profile=name, target=filename_target)
                 filename = dirname + '/' + self.filename_pattern.format(profile=name, target=filename_target,


### PR DESCRIPTION
I've come across several implausible values for `device_timestamp` (such as 182428140, which would be in october 1975, assuming millisecond). I guess it is due to improperly configured phones, or maybe some third party software that's mangeling the EXIF data on images before posting. Anyway. Since by the nature of stories, the `taken_at` timestamp (presumably when the instagram servers received the post) ought to be approximately when an image was actually taken. So there's no real value trying to use the timestamp provided by the photo-taking-device.